### PR TITLE
[Lab5] Add tx err monitor tables

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -493,6 +493,8 @@ namespace swss {
 #define CFG_SRV6_MY_SID_TABLE_NAME                  "SRV6_MY_SIDS"
 #define CFG_SRV6_MY_LOCATOR_TABLE_NAME              "SRV6_MY_LOCATORS"
 
+#define CFG_TX_ERR_TABLE_NAME              "TX_ERR_CFG"
+
 /***** STATE DATABASE *****/
 
 #define STATE_SWITCH_CAPABILITY_TABLE_NAME          "SWITCH_CAPABILITY"
@@ -589,6 +591,8 @@ namespace swss {
 #define STATE_OPER_VLAN_MEMBER_TABLE_NAME      "OPER_VLAN_MEMBER"
 #define STATE_OPER_FDB_TABLE_NAME              "OPER_FDB"
 #define STATE_OPER_PORT_TABLE_NAME             "OPER_PORT"
+
+#define STATE_TX_ERR_TABLE_NAME "TX_ERR_STATE"
 
 /***** Counter capability tables for Queue and Port ****/
 #define STATE_QUEUE_COUNTER_CAPABILITIES_NAME   "QUEUE_COUNTER_CAPABILITIES"


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Created a new tables in schema.h:
STATE_TX_ERR_TABLE_NAME "TX_ERR_STATE" to state db
CFG_TX_ERR_TABLE_NAME  "TX_ERR_CFG" to config db

**Why I did it**
To store and manage TX error monitoring data:
TX_ERR_CFG holds the configuration values such as threshold and period
TX_ERR_STATE keeps track of the current TX error monitoring status for each port

**How I verified it**
CLI commands:
redis-cli -n 4
hgetall "TX_ERR_CFG|config"
redis-cli -n 6
hgetall "TX_ERR_STATE|Ethernet140"

**Details if related**
